### PR TITLE
Fix #412 ShardingConnection gets the DatabaseMetaData before starting...

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,9 @@
+## 2.0.0.M2
+
+### 缺陷修正
+
+1. [ISSUE #412](https://github.com/shardingjdbc/sharding-jdbc/issues/412) ShardingConnection开启事务之前获取元数据，造成路由的部分连接事务开启失败
+
 ## 2.0.0.M1
 
 ### 里程碑

--- a/sharding-jdbc-core/src/main/java/io/shardingjdbc/core/jdbc/adapter/AbstractConnectionAdapter.java
+++ b/sharding-jdbc-core/src/main/java/io/shardingjdbc/core/jdbc/adapter/AbstractConnectionAdapter.java
@@ -55,10 +55,7 @@ public abstract class AbstractConnectionAdapter extends AbstractUnsupportedOpera
     @Override
     public final void setAutoCommit(final boolean autoCommit) throws SQLException {
         this.autoCommit = autoCommit;
-        if (cachedConnections.isEmpty()) {
-            recordMethodInvocation(Connection.class, "setAutoCommit", new Class[] {boolean.class}, new Object[] {autoCommit});
-            return;
-        }
+        recordMethodInvocation(Connection.class, "setAutoCommit", new Class[] {boolean.class}, new Object[] {autoCommit});
         for (Connection each : cachedConnections.values()) {
             each.setAutoCommit(autoCommit);
         }
@@ -117,10 +114,7 @@ public abstract class AbstractConnectionAdapter extends AbstractUnsupportedOpera
     @Override
     public final void setReadOnly(final boolean readOnly) throws SQLException {
         this.readOnly = readOnly;
-        if (cachedConnections.isEmpty()) {
-            recordMethodInvocation(Connection.class, "setReadOnly", new Class[] {boolean.class}, new Object[] {readOnly});
-            return;
-        }
+        recordMethodInvocation(Connection.class, "setReadOnly", new Class[] {boolean.class}, new Object[] {readOnly});
         for (Connection each : cachedConnections.values()) {
             each.setReadOnly(readOnly);
         }
@@ -134,10 +128,7 @@ public abstract class AbstractConnectionAdapter extends AbstractUnsupportedOpera
     @Override
     public final void setTransactionIsolation(final int level) throws SQLException {
         transactionIsolation = level;
-        if (cachedConnections.isEmpty()) {
-            recordMethodInvocation(Connection.class, "setTransactionIsolation", new Class[] {int.class}, new Object[] {level});
-            return;
-        }
+        recordMethodInvocation(Connection.class, "setTransactionIsolation", new Class[] {int.class}, new Object[] {level});
         for (Connection each : cachedConnections.values()) {
             each.setTransactionIsolation(level);
         }

--- a/sharding-jdbc-core/src/test/java/io/shardingjdbc/core/jdbc/adapter/ConnectionAdapterTest.java
+++ b/sharding-jdbc-core/src/test/java/io/shardingjdbc/core/jdbc/adapter/ConnectionAdapterTest.java
@@ -44,6 +44,7 @@ public final class ConnectionAdapterTest extends AbstractShardingJDBCDatabaseAnd
     @Test
     public void assertSetAutoCommit() throws SQLException {
         try (ShardingConnection actual = getShardingDataSource().getConnection()) {
+            assertThat(actual.getMetaData().getDatabaseProductName(), is(getCurrentDatabaseType().name()));
             assertTrue(actual.getAutoCommit());
             actual.setAutoCommit(false);
             actual.createStatement().executeQuery(sql);
@@ -102,6 +103,7 @@ public final class ConnectionAdapterTest extends AbstractShardingJDBCDatabaseAnd
     @Test
     public void assertSetReadOnly() throws SQLException {
         try (ShardingConnection actual = getShardingDataSource().getConnection()) {
+            assertThat(actual.getMetaData().getDatabaseProductName(), is(getCurrentDatabaseType().name()));
             assertTrue(actual.isReadOnly());
             actual.setReadOnly(false);
             actual.createStatement().executeQuery(sql);
@@ -129,6 +131,7 @@ public final class ConnectionAdapterTest extends AbstractShardingJDBCDatabaseAnd
     @Test
     public void assertSetTransactionIsolation() throws SQLException {
         try (ShardingConnection actual = getShardingDataSource().getConnection()) {
+            assertThat(actual.getMetaData().getDatabaseProductName(), is(getCurrentDatabaseType().name()));
             assertThat(actual.getTransactionIsolation(), is(Connection.TRANSACTION_READ_UNCOMMITTED));
             actual.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
             actual.createStatement().executeQuery(sql);


### PR DESCRIPTION
… the transaction, causing some of the routing connections to fail to start transaction.

Fixes #412.

