### PR TITLE
Fix incorrect usages of org.mockito.internal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,12 @@
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
             </dependency>
-            <dependency>
+	        <dependency>
+		        <groupId>org.apache.commons</groupId>
+		        <artifactId>commons-lang3</artifactId>
+		        <version>3.6</version>
+	        </dependency>
+	        <dependency>
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-framework</artifactId>
                 <version>${curator.version}</version>

--- a/sharding-jdbc-core/pom.xml
+++ b/sharding-jdbc-core/pom.xml
@@ -35,6 +35,10 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
+	    <dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-lang3</artifactId>
+	    </dependency>
         <dependency>
             <groupId>org.dbunit</groupId>
             <artifactId>dbunit</artifactId>

--- a/sharding-jdbc-core/src/test/java/io/shardingjdbc/core/parsing/lexer/analyzer/TokenizerTest.java
+++ b/sharding-jdbc-core/src/test/java/io/shardingjdbc/core/parsing/lexer/analyzer/TokenizerTest.java
@@ -23,7 +23,8 @@ import io.shardingjdbc.core.parsing.lexer.token.Symbol;
 import io.shardingjdbc.core.parsing.lexer.token.Token;
 import io.shardingjdbc.core.parsing.lexer.token.TokenType;
 import org.junit.Test;
-import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -119,7 +120,7 @@ public final class TokenizerTest {
     private void assertScanVariable(final String sql, final String literals) {
         String formatSql = String.format(sql, literals);
         Tokenizer tokenizer = new Tokenizer(formatSql, dictionary, formatSql.indexOf("@"));
-        assertTrue(new ReflectionEquals(tokenizer.scanVariable()).matches(new Token(Literals.VARIABLE, literals, formatSql.indexOf("WHERE") - 1)));
+        assertTrue(EqualsBuilder.reflectionEquals(tokenizer.scanVariable(), new Token(Literals.VARIABLE, literals, formatSql.indexOf("WHERE") - 1)));
     }
     
     @Test
@@ -148,30 +149,30 @@ public final class TokenizerTest {
     private void assertScanNumber(final String sql, final String literals, final TokenType type) {
         String formatSql = String.format(sql, literals);
         Tokenizer tokenizer = new Tokenizer(formatSql, dictionary, sql.indexOf("=") + 1);
-        assertTrue(new ReflectionEquals(tokenizer.scanNumber()).matches(new Token(type, literals, formatSql.length())));
+        assertTrue(EqualsBuilder.reflectionEquals(tokenizer.scanNumber(), new Token(type, literals, formatSql.length())));
     }
     
     private void assertScanHexDecimal(final String sql, final String literals, final TokenType type) {
         String formatSql = String.format(sql, literals);
         Tokenizer tokenizer = new Tokenizer(formatSql, dictionary, sql.indexOf("=") + 1);
-        assertTrue(new ReflectionEquals(tokenizer.scanHexDecimal()).matches(new Token(type, literals, formatSql.length())));
+        assertTrue(EqualsBuilder.reflectionEquals(tokenizer.scanHexDecimal(), new Token(type, literals, formatSql.length())));
     }
     
     @Test
     public void assertScanNChars() {
         String sql = "SELECT * FROM ORDER, XX_TABLE AS `table` WHERE YY=N'xx' And group =-1 GROUP BY YY";
         Tokenizer tokenizer = new Tokenizer(sql, dictionary, sql.indexOf("ORDER"));
-        assertTrue(new ReflectionEquals(tokenizer.scanIdentifier()).matches(new Token(Literals.IDENTIFIER, "ORDER", sql.indexOf(","))));
+        assertTrue(EqualsBuilder.reflectionEquals(tokenizer.scanIdentifier(), new Token(Literals.IDENTIFIER, "ORDER", sql.indexOf(","))));
         tokenizer = new Tokenizer(sql, dictionary, sql.indexOf("GROUP"));
-        assertTrue(new ReflectionEquals(tokenizer.scanIdentifier()).matches(new Token(DefaultKeyword.GROUP, "GROUP", sql.indexOf("BY") - 1)));
+        assertTrue(EqualsBuilder.reflectionEquals(tokenizer.scanIdentifier(), new Token(DefaultKeyword.GROUP, "GROUP", sql.indexOf("BY") - 1)));
         tokenizer = new Tokenizer(sql, dictionary, sql.indexOf("`"));
-        assertTrue(new ReflectionEquals(tokenizer.scanIdentifier()).matches(new Token(Literals.IDENTIFIER, "`table`", sql.indexOf("WHERE") - 1)));
+        assertTrue(EqualsBuilder.reflectionEquals(tokenizer.scanIdentifier(), new Token(Literals.IDENTIFIER, "`table`", sql.indexOf("WHERE") - 1)));
         tokenizer = new Tokenizer(sql, dictionary, sql.indexOf("YY"));
-        assertTrue(new ReflectionEquals(tokenizer.scanIdentifier()).matches(new Token(Literals.IDENTIFIER, "YY", sql.indexOf("="))));
+        assertTrue(EqualsBuilder.reflectionEquals(tokenizer.scanIdentifier(), new Token(Literals.IDENTIFIER, "YY", sql.indexOf("="))));
         tokenizer = new Tokenizer(sql, dictionary, sql.indexOf("=-"));
-        assertTrue(new ReflectionEquals(tokenizer.scanSymbol()).matches(new Token(Symbol.EQ, "=", sql.indexOf("=-") + 1)));
+        assertTrue(EqualsBuilder.reflectionEquals(tokenizer.scanSymbol(), new Token(Symbol.EQ, "=", sql.indexOf("=-") + 1)));
         tokenizer = new Tokenizer(sql, dictionary, sql.indexOf("'"));
-        assertTrue(new ReflectionEquals(tokenizer.scanChars()).matches(new Token(Literals.CHARS, "xx", sql.indexOf("And") - 1)));
+        assertTrue(EqualsBuilder.reflectionEquals(tokenizer.scanChars(), new Token(Literals.CHARS, "xx", sql.indexOf("And") - 1)));
     }
     
     @Test(expected = UnterminatedCharException.class)

--- a/sharding-jdbc-core/src/test/java/io/shardingjdbc/core/parsing/parser/jaxb/helper/ParserAssertHelper.java
+++ b/sharding-jdbc-core/src/test/java/io/shardingjdbc/core/parsing/parser/jaxb/helper/ParserAssertHelper.java
@@ -19,8 +19,7 @@ import io.shardingjdbc.core.parsing.parser.token.OrderByToken;
 import io.shardingjdbc.core.parsing.parser.token.RowCountToken;
 import io.shardingjdbc.core.parsing.parser.token.SQLToken;
 import io.shardingjdbc.core.parsing.parser.token.TableToken;
-
-import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -34,11 +33,11 @@ import static org.junit.Assert.assertTrue;
 public class ParserAssertHelper {
     
     public static void assertTables(final io.shardingjdbc.core.parsing.parser.jaxb.Tables expected, final io.shardingjdbc.core.parsing.parser.context.table.Tables actual) {
-        assertTrue(new ReflectionEquals(ParserJAXBHelper.getTables(expected)).matches(actual));
+        assertTrue(EqualsBuilder.reflectionEquals(ParserJAXBHelper.getTables(expected), actual));
     }
     
     public static void assertConditions(final io.shardingjdbc.core.parsing.parser.jaxb.Conditions expected, final io.shardingjdbc.core.parsing.parser.context.condition.Conditions actual, final boolean isPreparedStatement) {
-        assertTrue(new ReflectionEquals(buildExpectedConditions(expected, isPreparedStatement)).matches(actual));
+        assertTrue(EqualsBuilder.reflectionEquals(buildExpectedConditions(expected, isPreparedStatement), actual));
     }
     
     private static io.shardingjdbc.core.parsing.parser.context.condition.Conditions buildExpectedConditions(final io.shardingjdbc.core.parsing.parser.jaxb.Conditions conditions, final boolean isPreparedStatement) {
@@ -87,7 +86,7 @@ public class ParserAssertHelper {
         Iterator<io.shardingjdbc.core.parsing.parser.jaxb.SQLToken> sqlTokenIterator = filteredSqlTokens.iterator();
         for (SQLToken each : actual) {
             SQLToken sqlToken = buildExpectedSQLToken(sqlTokenIterator.next(), isPreparedStatement);
-            assertTrue(new ReflectionEquals(sqlToken).matches(each));
+            assertTrue(EqualsBuilder.reflectionEquals(sqlToken, each));
         }
         assertFalse(sqlTokenIterator.hasNext());
     }
@@ -143,10 +142,10 @@ public class ParserAssertHelper {
             return;
         }
         if (null != expected.getRowCount()) {
-            assertTrue(new ReflectionEquals(expected.getRowCount()).matches(actual.getRowCount()));
+            assertTrue(EqualsBuilder.reflectionEquals(expected.getRowCount(), actual.getRowCount()));
         }
         if (null != expected.getOffset()) {
-            assertTrue(new ReflectionEquals(expected.getOffset()).matches(actual.getOffset()));
+            assertTrue(EqualsBuilder.reflectionEquals(expected.getOffset(), actual.getOffset()));
         }
     }
     
@@ -179,7 +178,7 @@ public class ParserAssertHelper {
         for (OrderItem each : actual) {
             OrderItem expectedOrderItem = orderByColumns.next();
             // TODO assert nullOrderType
-            assertTrue(new ReflectionEquals(expectedOrderItem, "nullOrderType").matches(each));
+            assertTrue(EqualsBuilder.reflectionEquals(expectedOrderItem, each, "nullOrderType"));
         }
         assertFalse(orderByColumns.hasNext());
     }
@@ -189,7 +188,7 @@ public class ParserAssertHelper {
         for (OrderItem each : actual) {
             OrderItem groupByColumn = groupByColumns.next();
             // TODO assert nullOrderType
-            assertTrue(new ReflectionEquals(groupByColumn, "nullOrderType").matches(each));
+            assertTrue(EqualsBuilder.reflectionEquals(groupByColumn, each, "nullOrderType"));
         }
         assertFalse(groupByColumns.hasNext());
     }
@@ -198,9 +197,9 @@ public class ParserAssertHelper {
         Iterator<AggregationSelectItem> aggregationSelectItems = expected.iterator();
         for (AggregationSelectItem each : actual) {
             AggregationSelectItem aggregationSelectItem = aggregationSelectItems.next();
-            assertTrue(new ReflectionEquals(aggregationSelectItem, "derivedAggregationSelectItems").matches(each));
+            assertTrue(EqualsBuilder.reflectionEquals(aggregationSelectItem, each, "derivedAggregationSelectItems"));
             for (int i = 0; i < each.getDerivedAggregationSelectItems().size(); i++) {
-                assertTrue(new ReflectionEquals(aggregationSelectItem.getDerivedAggregationSelectItems().get(i)).matches(each.getDerivedAggregationSelectItems().get(i)));
+                assertTrue(EqualsBuilder.reflectionEquals(aggregationSelectItem.getDerivedAggregationSelectItems().get(i), each.getDerivedAggregationSelectItems().get(i)));
             }
         }
         assertFalse(aggregationSelectItems.hasNext());


### PR DESCRIPTION
Hey! I saw you were depending on several `org.mockito.internal` classes. As we (the Mockito core developers) do not guarantee backwards compatibility on these classes, I converted them for you to the equivalent public API. Probably your IDE was suggesting the wrong import upon autocompletion.