### PR TITLE
fix #544.Add the spring-boot-configuration-processor jar to generate …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,12 @@
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-configuration-processor</artifactId>
+                <version>${spring-boot.version}</version>
+                <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-test</artifactId>
                 <version>${spring-boot.version}</version>
                 <scope>test</scope>

--- a/sharding-jdbc-core-spring/pom.xml
+++ b/sharding-jdbc-core-spring/pom.xml
@@ -50,6 +50,11 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/sharding-jdbc-orchestration-spring/pom.xml
+++ b/sharding-jdbc-orchestration-spring/pom.xml
@@ -54,6 +54,11 @@
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
Add the spring-boot-configuration-processor jar to generate configuration meta-data file from items annotated with @ConfigurationProperties

Fixes #544.

Changes proposed in this pull request:
- Add spring-boot-configuration-processor optional dependency.