### PR TITLE
修复yaml换行导致的配置多了空格问题  @issue #577

### DIFF
--- a/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-boot-starter/src/main/java/io/shardingjdbc/orchestration/spring/boot/OrchestrationSpringBootConfiguration.java
+++ b/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-boot-starter/src/main/java/io/shardingjdbc/orchestration/spring/boot/OrchestrationSpringBootConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
@@ -75,15 +76,17 @@ public class OrchestrationSpringBootConfiguration implements EnvironmentAware {
     private void setDataSourceMap(final Environment environment) {
         RelaxedPropertyResolver propertyResolver = new RelaxedPropertyResolver(environment, "sharding.jdbc.datasource.");
         String dataSources = propertyResolver.getProperty("names");
+        Preconditions.checkState(!StringUtils.isEmpty(dataSources), "Wrong datasource properties, empty datasource !");
+        dataSources = dataSources.trim();
         for (String each : dataSources.split(",")) {
-            try {
-                Map<String, Object> dataSourceProps = propertyResolver.getSubProperties(each + ".");
-                Preconditions.checkState(!dataSourceProps.isEmpty(), "Wrong datasource properties!");
-                DataSource dataSource = DataSourceUtil.getDataSource(dataSourceProps.get("type").toString(), dataSourceProps);
-                dataSourceMap.put(each, dataSource);
-            } catch (final ReflectiveOperationException ex) {
-                throw new ShardingJdbcException("Can't find datasource type!", ex);
-            }
+        	try {
+        		Map<String, Object> dataSourceProps = propertyResolver.getSubProperties(each + ".");
+        		Preconditions.checkState(!dataSourceProps.isEmpty(), String.format("Wrong datasource [%s] properties!", each));
+        		DataSource dataSource = DataSourceUtil.getDataSource(dataSourceProps.get("type").toString(), dataSourceProps);
+        		dataSourceMap.put(each, dataSource);
+        	} catch (final ReflectiveOperationException ex) {
+        		throw new ShardingJdbcException("Can't find datasource type!", ex);
+        	}
         }
     }
 }


### PR DESCRIPTION
Fixes #ISSUSE_ID.
 #577

Changes proposed in this pull request:
- 修复yaml配置datasource换行时导致的配置多了空格，进而导致读取datasource异常
-添加日志信息更加详细的提示用户datasource配置失败的具体原因
