### PR TITLE
解决oracle ojdbc6 11g 驱动更新条数返回不正确的问题

### DIFF
--- a/sharding-jdbc-core/src/main/java/io/shardingjdbc/core/jdbc/adapter/AbstractStatementAdapter.java
+++ b/sharding-jdbc-core/src/main/java/io/shardingjdbc/core/jdbc/adapter/AbstractStatementAdapter.java
@@ -111,10 +111,11 @@ public abstract class AbstractStatementAdapter extends AbstractUnsupportedOperat
         long result = 0;
         boolean hasResult = false;
         for (Statement each : getRoutedStatements()) {
-            if (each.getUpdateCount() > -1) {
+            int updateCount = each.getUpdateCount();
+            if (updateCount > -1) {
                 hasResult = true;
             }
-            result += each.getUpdateCount();
+            result += updateCount;
         }
         if (result > Integer.MAX_VALUE) {
             result = Integer.MAX_VALUE;


### PR DESCRIPTION
解决oracle ojdbc6 11g 驱动更新条数返回不正确的问题
oracle ojdbc6 11g 驱动中OraclePreparedStatement属性noMoreUpdateCounts属性在执行OracleStatement的getUpdateCount()方法是执行一次后修改noMoreUpdateCounts的值，当再次执行getUpdateCount()方法时，以前的更新条数就会丢失

解决方案：避免多次执行getUpdateCount


Fixes #https://github.com/shardingjdbc/sharding-jdbc/issues/587

Changes proposed in this pull request:
-
-
-
