### PR TITLE
change HintManager.getInstance  to  "Thread Singleton mode"

### DIFF
--- a/sharding-jdbc-core/src/main/java/io/shardingjdbc/core/api/HintManager.java
+++ b/sharding-jdbc-core/src/main/java/io/shardingjdbc/core/api/HintManager.java
@@ -62,11 +62,8 @@ public final class HintManager implements AutoCloseable {
      * @return  {@code HintManager} instance
      */
     public static HintManager getInstance() {
-        HintManager result = HintManagerHolder.get();
-        if (result == null){
-            result = new HintManager();
-            HintManagerHolder.setHintManager(result);
-        }
+        HintManager result = new HintManager();
+        HintManagerHolder.setHintManager(result);
         return result;
     }
     

--- a/sharding-jdbc-core/src/main/java/io/shardingjdbc/core/api/HintManager.java
+++ b/sharding-jdbc-core/src/main/java/io/shardingjdbc/core/api/HintManager.java
@@ -62,8 +62,11 @@ public final class HintManager implements AutoCloseable {
      * @return  {@code HintManager} instance
      */
     public static HintManager getInstance() {
-        HintManager result = new HintManager();
-        HintManagerHolder.setHintManager(result);
+        HintManager result = HintManagerHolder.get();
+        if (result == null){
+            result = new HintManager();
+            HintManagerHolder.setHintManager(result);
+        }
         return result;
     }
     

--- a/sharding-jdbc-core/src/main/java/io/shardingjdbc/core/hint/HintManagerHolder.java
+++ b/sharding-jdbc-core/src/main/java/io/shardingjdbc/core/hint/HintManagerHolder.java
@@ -102,4 +102,12 @@ public final class HintManagerHolder {
     public static void clear() {
         HINT_MANAGER_HOLDER.remove();
     }
+
+    /**
+     * Get hint manager in current thread
+     * @return HintManager
+     */
+    public static HintManager get(){
+        return HINT_MANAGER_HOLDER.get();
+    }
 }


### PR DESCRIPTION
使用场景：
公司内部有自己的framework，在framework里会通过hystrix对sql的执行进行管理，由于hystrix会开辟新的线程执行调用sharding-jdbc，此时在逻辑层里，用户（同事）通过HintManager进行强制路由，但是sharding-jdbc在hystrix线程里执行，因此无法获得用户的HintManager设置。

通过修改HintManager.getInstance为当前线程的单例模式，在framework里可以获取到用户设置的HintManager，从而可以在framework进行逻辑控制，比如copy到hystrix线程等。