### PR TITLE
ExecutorEngine略微优雅一点的关闭方式

### DIFF
--- a/sharding-jdbc-core/src/main/java/io/shardingjdbc/core/executor/ExecutorEngine.java
+++ b/sharding-jdbc-core/src/main/java/io/shardingjdbc/core/executor/ExecutorEngine.java
@@ -61,7 +61,7 @@ import java.util.concurrent.TimeUnit;
 public final class ExecutorEngine implements AutoCloseable {
     
     private static final ThreadPoolExecutor shutdownExecutor = new ThreadPoolExecutor(
-            0, 1, 0, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>(10), new ThreadFactoryBuilder().setDaemon(true).setNameFormat("ShardingJDBC-ExecutorEngineCloseTimer%d").build());
+            0, 1, 0, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>(10), new ThreadFactoryBuilder().setDaemon(true).setNameFormat("ShardingJDBC-ExecutorEngineCloseTimer").build());
     
     private final ListeningExecutorService executorService;
     

--- a/sharding-jdbc-core/src/main/java/io/shardingjdbc/core/executor/ExecutorEngine.java
+++ b/sharding-jdbc-core/src/main/java/io/shardingjdbc/core/executor/ExecutorEngine.java
@@ -219,7 +219,7 @@ public final class ExecutorEngine implements AutoCloseable {
     public void close() {
         executorService.shutdown();
         try {
-            if (!executorService.awaitTermination(5, TimeUnit.MILLISECONDS)) {
+            if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
                 executorService.shutdownNow();
             }
         } catch (final InterruptedException ignored) {
@@ -235,15 +235,16 @@ public final class ExecutorEngine implements AutoCloseable {
             @Override
             public void run() {
                 try {
-                    for (int i = 0; i < 10000; i++) {
+                    //这里是通过interrupt去中断执行任务，如果对interrupt没有响应的任务或catch住InterruptedException的任务将永远无法关闭
+                    while (true) {
                         executorService.shutdownNow();
 
-                        if (executorService.awaitTermination(5, TimeUnit.MILLISECONDS)) {
+                        if (executorService.awaitTermination(100, TimeUnit.MILLISECONDS)) {
                             break;
                         }
                     }
+                } catch (InterruptedException e) {
                     log.error("ExecutorEngine can not been terminated");
-                } catch (InterruptedException ignored) {
                 }
             }
         });

--- a/sharding-jdbc-core/src/main/java/io/shardingjdbc/core/jdbc/core/datasource/ShardingDataSource.java
+++ b/sharding-jdbc-core/src/main/java/io/shardingjdbc/core/jdbc/core/datasource/ShardingDataSource.java
@@ -74,8 +74,9 @@ public class ShardingDataSource extends AbstractDataSourceAdapter implements Aut
         int originalExecutorSize = shardingProperties.getValue(ShardingPropertiesConstant.EXECUTOR_SIZE);
         int newExecutorSize = newShardingProperties.getValue(ShardingPropertiesConstant.EXECUTOR_SIZE);
         if (originalExecutorSize != newExecutorSize) {
-            executorEngine.close();
+            ExecutorEngine originalExecutorEngine = executorEngine;
             executorEngine = new ExecutorEngine(newExecutorSize);
+            originalExecutorEngine.close();
         }
         boolean newShowSQL = newShardingProperties.getValue(ShardingPropertiesConstant.SQL_SHOW);
         shardingProperties = newShardingProperties;


### PR DESCRIPTION
Fixes [#573](https://github.com/shardingjdbc/sharding-jdbc/issues/573)

1、重新加载配置时调用ExecutorEngine的关闭方法存在一定时间的空档期，导致sj无法提交新的任务修改为先重建ExecutorEngine然后再关闭
2、修改直接调用shutdownNow来强制取消正在执行的任务为先调用shutdown等待5秒后才强制取消正在执行的任务
3、原来close失败抛异常修改为使用线程来继续调用shutdownNow方法


